### PR TITLE
refactor: use undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,6 @@
 		"tsc-watch": "^5.0.3",
 		"typescript": "^4.6.4"
 	},
-	"dependencies": {
-		"axios": "^0.27.2"
-	},
 	"prettier": "@sapphire/prettier-config",
 	"eslintConfig": {
 		"extends": "@sapphire"
@@ -65,5 +62,8 @@
 			"git add"
 		]
 	},
-	"packageManager": "yarn@3.2.0"
+	"packageManager": "yarn@3.2.0",
+	"dependencies": {
+		"undici": "^5.0.0"
+	}
 }

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,4 +1,4 @@
-import fetch from 'axios';
+import { Nico } from '../utils/Nico';
 import type { DailyForecast, Observation, RainForecast, ThreeHourForecast, Warnings } from './structures';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
@@ -11,7 +11,7 @@ export class BOM {
 	 */
 	public static async getObservations(geohash: string): Promise<Observation> {
 		try {
-			return (await fetch(`https://api.weather.bom.gov.au/v1/locations/${geohash}/observations`)).data as Observation;
+			return await Nico.get<Observation>(`/locations/${geohash}/observations`);
 		} catch {
 			throw new Error('[BOMApiError] - An Invalid Geohash was provided');
 		}
@@ -24,7 +24,7 @@ export class BOM {
 	 */
 	public static async getWarnings(geohash: string): Promise<Warnings> {
 		try {
-			return (await fetch(`https://api.weather.bom.gov.au/v1/locations/${geohash}/warnings`)).data as Warnings;
+			return await Nico.get<Warnings>(`/locations/${geohash}/warnings`);
 		} catch {
 			throw new Error('[BOMApiError] - An Invalid Geohash was provided');
 		}
@@ -37,7 +37,7 @@ export class BOM {
 	 */
 	public static async getDailyForecast(geohash: string): Promise<DailyForecast> {
 		try {
-			return (await fetch(`https://api.weather.bom.gov.au/v1/locations/${geohash}/forecasts/daily`)).data as DailyForecast;
+			return await Nico.get<DailyForecast>(`/locations/${geohash}/forecasts/daily`);
 		} catch {
 			throw new Error('[BOMApiError] - An Invalid Geohash was provided');
 		}
@@ -50,7 +50,7 @@ export class BOM {
 	 */
 	public static async getThreeHourForecast(geohash: string): Promise<ThreeHourForecast> {
 		try {
-			return (await fetch(`https://api.weather.bom.gov.au/v1/locations/${geohash}/forecasts/3-hourly`)).data as ThreeHourForecast;
+			return await Nico.get<ThreeHourForecast>(`/locations/${geohash}/forecasts/3-hourly`);
 		} catch {
 			throw new Error('[BOMApiError] - An Invalid Geohash was provided');
 		}
@@ -63,7 +63,7 @@ export class BOM {
 	 */
 	public static async getRainForecast(geohash: string): Promise<RainForecast> {
 		try {
-			return (await fetch(`https://api.weather.bom.gov.au/v1/locations/${geohash}/forecast/rain`)).data as RainForecast;
+			return await Nico.get<RainForecast>(`/locations/${geohash}/forecast/rain`);
 		} catch {
 			throw new Error('[BOMApiError] - An Invalid Geohash was provided');
 		}

--- a/src/utils/Nico.ts
+++ b/src/utils/Nico.ts
@@ -1,0 +1,17 @@
+import { fetch, RequestInit } from 'undici';
+
+/* eslint-disable @typescript-eslint/no-extraneous-class */
+export class Nico {
+	private static rootAPI = 'https://api.weather.bom.gov.au/v1';
+
+	public static get<type>(route: string, options?: RequestInit): Promise<type> {
+		return new Promise((resolve, reject) => {
+			fetch(`${this.rootAPI}${route}`, {
+				...options
+			})
+				.then((res) => res.json())
+				.then((res) => resolve(res as type))
+				.catch((err) => reject(err));
+		});
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,23 +502,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asynckit@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "asynckit@npm:0.4.0"
-  checksum: 7b78c451df768adba04e2d02e63e2d0bf3b07adcd6e42b4cf665cb7ce899bedd344c69a1dcbce355b5f972d597b25aaa1c1742b52cffd9caccb22f348114f6be
-  languageName: node
-  linkType: hard
-
-"axios@npm:^0.27.2":
-  version: 0.27.2
-  resolution: "axios@npm:0.27.2"
-  dependencies:
-    follow-redirects: ^1.14.9
-    form-data: ^4.0.0
-  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -543,7 +526,6 @@ __metadata:
     "@types/node": ^17.0.30
     "@typescript-eslint/eslint-plugin": ^5.21.0
     "@typescript-eslint/parser": ^5.21.0
-    axios: ^0.27.2
     eslint: ^8.14.0
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.0.0
@@ -556,6 +538,7 @@ __metadata:
     ts-node-dev: ^1.1.8
     tsc-watch: ^5.0.3
     typescript: ^4.6.4
+    undici: ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -731,15 +714,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "combined-stream@npm:1.0.8"
-  dependencies:
-    delayed-stream: ~1.0.0
-  checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
-  languageName: node
-  linkType: hard
-
 "commander@npm:^8.3.0":
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
@@ -802,13 +776,6 @@ __metadata:
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: edb65dd0d7d1b9c40b2f50219aef30e116cedd6fc79290e740972c132c09106d2e80aa0bc8826673dd5a00222d4179c84b36a790eef63a4c4bca75a37ef90804
-  languageName: node
-  linkType: hard
-
-"delayed-stream@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "delayed-stream@npm:1.0.0"
-  checksum: 46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
   languageName: node
   linkType: hard
 
@@ -1198,27 +1165,6 @@ __metadata:
   version: 3.2.5
   resolution: "flatted@npm:3.2.5"
   checksum: 3c436e9695ccca29620b4be5671dd72e5dd0a7500e0856611b7ca9bd8169f177f408c3b9abfa78dfe1493ee2d873e2c119080a8a9bee4e1a186a9e60ca6c89f1
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.14.9":
-  version: 1.14.9
-  resolution: "follow-redirects@npm:1.14.9"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "form-data@npm:4.0.0"
-  dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.8
-    mime-types: ^2.1.12
-  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -1815,22 +1761,6 @@ __metadata:
     braces: ^3.0.2
     picomatch: ^2.3.1
   checksum: 02a17b671c06e8fefeeb6ef996119c1e597c942e632a21ef589154f23898c9c6a9858526246abb14f8bca6e77734aa9dcf65476fca47cedfb80d9577d52843fc
-  languageName: node
-  linkType: hard
-
-"mime-db@npm:1.52.0":
-  version: 1.52.0
-  resolution: "mime-db@npm:1.52.0"
-  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.1.12":
-  version: 2.1.35
-  resolution: "mime-types@npm:2.1.35"
-  dependencies:
-    mime-db: 1.52.0
-  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
   languageName: node
   linkType: hard
 
@@ -2885,6 +2815,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 1cb434fbc637d347be90e3a0c6cd05e33c38f941713c8786d3031faf1842c2c148ba91d2fac01e7276b0ae3249b8633f1660e32686cc7a8c6a8fd5361dc52c66
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "undici@npm:5.0.0"
+  checksum: 98bb9914aa0647840ce6fd518ac828b7760df8d9b747680d11260fcb4f50af0029b0513e5600bf0d3a812d9e3f8d9d787bbcbcee7b9e75aa5f7de6f9b0212898
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace `axios` with `undici` for a lesser bundler size and speed.